### PR TITLE
Drucklayout: Einrückung für `headingOnly`-Blöcke anpassen

### DIFF
--- a/Klausurbewertung/src/components/PrintView.tsx
+++ b/Klausurbewertung/src/components/PrintView.tsx
@@ -15,12 +15,13 @@ interface PrintViewProps {
 
 interface PrintRow {
   nodeId: string;
-  depth: number;
+  indentDepth: number;
   title: string;
   richContent: string;
   maxPoints?: number;
   isScorable?: boolean;
   isBonus?: boolean;
+  isHeadingOnly: boolean;
 }
 
 const estimateWeight = (row: PrintRow): number => {
@@ -56,20 +57,52 @@ const getStudents = (exam: ExamRecord): Student[] =>
   exam.students.slice().sort((left, right) => left.sortIndex - right.sortIndex).filter((student) => student.aktiv);
 
 export const PrintView = ({ exam }: PrintViewProps) => {
+  const effectiveIndentDepth = useMemo(() => {
+    const nodeMap = new Map(exam.structure.map((node) => [node.id, node]));
+    const cache = new Map<string, number>();
+
+    const resolveDepth = (nodeId: string): number => {
+      const cached = cache.get(nodeId);
+      if (cached !== undefined) {
+        return cached;
+      }
+
+      const node = nodeMap.get(nodeId);
+      if (!node || !node.parentId) {
+        cache.set(nodeId, 0);
+        return 0;
+      }
+
+      const parent = nodeMap.get(node.parentId);
+      if (!parent) {
+        cache.set(nodeId, 0);
+        return 0;
+      }
+
+      const parentDepth = resolveDepth(parent.id);
+      const depth = parent.type === "headingOnly" ? parentDepth : parentDepth + 1;
+      cache.set(nodeId, depth);
+      return depth;
+    };
+
+    return resolveDepth;
+  }, [exam.structure]);
+
   const rows = useMemo(
     () =>
       flattenStructure(exam.structure)
         .filter((node) => node.printVisibility !== "hidden" && node.printVisibility !== "screenOnly")
         .map((node) => ({
           nodeId: node.id,
-          depth: node.depth,
+          indentDepth: node.type === "headingOnly" ? 0 : effectiveIndentDepth(node.id),
           title: node.title,
           richContent: node.richContent,
           maxPoints: node.maxPoints,
           isScorable: node.isScorable,
-          isBonus: node.isBonus
+          isBonus: node.isBonus,
+          isHeadingOnly: node.type === "headingOnly"
         })),
-    [exam.structure]
+    [exam.structure, effectiveIndentDepth]
   );
   const students = useMemo(() => getStudents(exam), [exam]);
   const scheme = resolveGradeScheme(exam.metadata);
@@ -116,13 +149,16 @@ export const PrintView = ({ exam }: PrintViewProps) => {
                 <tbody>
                   {pageRows.map((row) => {
                     const totalsForRow = getNodeTotalsForStudent(exam, row.nodeId, student.id);
+                    const rowPadding = `${12 + row.indentDepth * 16}px`;
                     return (
                       <tr key={row.nodeId}>
-                        <td style={{ paddingLeft: `${12 + row.depth * 16}px` }}>
+                        <td style={{ paddingLeft: rowPadding }}>
                           <strong>{row.title || "-"}</strong>
                           {row.isBonus ? <div>Bonus</div> : null}
                         </td>
-                        <td><MarkdownPreview content={row.richContent} /></td>
+                        <td className={row.isHeadingOnly ? "" : "print-inline-content"} style={{ paddingLeft: rowPadding }}>
+                          {row.isHeadingOnly ? null : <MarkdownPreview content={row.richContent} />}
+                        </td>
                         <td>
                           {row.isScorable
                             ? `${totalsForRow.achieved.toFixed(1)} / ${(row.maxPoints ?? 0).toFixed(1)}`

--- a/Klausurbewertung/src/styles/global.css
+++ b/Klausurbewertung/src/styles/global.css
@@ -445,6 +445,19 @@ a {
   align-items: flex-end;
 }
 
+.print-inline-content .markdown-preview {
+  display: inline;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.print-inline-content .markdown-preview p {
+  display: inline;
+  margin: 0;
+}
+
 .grade-table {
   width: auto;
   min-width: 180px;


### PR DESCRIPTION
### Motivation
- Beim Erzeugen der Druckausgabe sollen reine Überschriften (`headingOnly`) die Einrückung nachfolgender Blöcke nicht erhöhen, damit neue Blöcke/Kriterien nur eingerückt werden, wenn der vorherige Block keine Überschrift war. 
- Überschriften sollen in der Druckansicht als reine Überschrift ohne zusätzlichen Zeilenumbruch für den Inhalt erscheinen, während Inhalte von Nicht-Überschriften entsprechend eingerückt und inline dargestellt werden.

### Description
- In `src/components/PrintView.tsx` wurde ein `useMemo` (`effectiveIndentDepth`) ergänzt, das die effektive Einrückung berechnet und `headingOnly`-Eltern beim Hochzählen der Tiefe ignoriert. 
- Die `PrintRow`-Struktur verwendet nun `indentDepth` und ein Flag `isHeadingOnly`, und die berechnete Einrückung wird sowohl auf die Titel- als auch auf die Inhaltszelle angewendet, wobei `headingOnly`-Zeilen keinen Inhalt rendern. 
- Die Inhaltszelle rendert für Nicht-Überschriften weiterhin das Markdown, für Überschriften jedoch `null`, damit keine neue Zeile begonnen wird. 
- In `src/styles/global.css` wurde `.print-inline-content .markdown-preview` hinzugefügt, um Markdown-Inhalt inline (ohne Blockrand/Absatz) darzustellen und so Zeilenumbrüche zu verhindern.

### Testing
- Automatisierte Tests wurden mit `npm test` ausgeführt und alle Tests sind erfolgreich (`src/test/logic.test.ts` — 6 Tests, alle bestanden). 
- Ein Build mit `npm run build` wurde versucht, schlägt jedoch im vorhandenen Projekt fehl wegen eines TypeScript-/`vite.config.ts`-Typsfehlers (Property `test` nicht kompatibel mit `UserConfigExport`), weshalb der Build-Fehler projektextern ist und nicht durch diese Änderung verursacht wurde.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3d83ea918833383fc425b1ab778c8)